### PR TITLE
Update Qt4 upstream URL

### DIFF
--- a/org.openmw.OpenMW.json
+++ b/org.openmw.OpenMW.json
@@ -116,7 +116,7 @@
         "sources": [
           {
             "type": "archive",
-            "url": "https://download.qt.io/official_releases/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz",
+            "url": "https://download.qt.io/archive/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz",
             "sha256": "e2882295097e47fe089f8ac741a95fef47e0a73a3f3cdf21b56990638f626ea0"
           }
         ],


### PR DESCRIPTION

**Before:**
Upstream URL has moved, failing the build.

```
# build output excerpt
Downloading https://download.qt.io/official_releases/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz
Failed to download sources: module qt4: The requested URL returned error: 404 Not Found
```

**After:** Builds successfully. :ok_hand: 