### PR TITLE
update deprecated boost url

### DIFF
--- a/org.openmw.OpenMW.yaml
+++ b/org.openmw.OpenMW.yaml
@@ -37,7 +37,7 @@ modules:
       - ./b2 install
     sources:
       - type: archive
-        url: https://boostorg.jfrog.io/artifactory/main/release/1.75.0/source/boost_1_75_0.tar.gz
+        url: https://archives.boost.io/release/1.75.0/source/boost_1_75_0.tar.gz
         sha256: aeb26f80e80945e82ee93e5939baebdca47b9dee80a07d3144be1e1a6a66dd6a
 
   - name: collada-dom


### PR DESCRIPTION


Download repository url has moved

refer: https://lists.boost.org/Archives/boost/2024/05/256914.php
